### PR TITLE
Add basic feed fetching from URL file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,9 @@ ice-rs = "0.3.0"
 libc = { version = "0.2.172", features = ["const-extern-fn", "use_std"] }
 log = "0.4.27"
 rand = { version = "0.9.1", features = ["log", "serde"] }
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["blocking", "rustls-tls"] }
+feed-rs = "2.3.1"
 rusqlite = "0.35.0"
+
+[features]
+gui = []

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ cargo build
 
 The project is still in a very early stage but should compile with the stable Rust toolchain.
 
+## Usage
+
+Irontide can read a list of feed URLs from a file and print their titles:
+
+```bash
+irontide --url-file urls.txt
+```
+
+Each non-empty, non-comment line in `urls.txt` should contain a valid feed URL.
+
 ## License
 
 The code is released under the terms of the CC0 license. See the [LICENSE](LICENSE) file for details.

--- a/src/local/cli/args.rs
+++ b/src/local/cli/args.rs
@@ -1,4 +1,7 @@
 // CLI arguments struct, derived from C++ options in newsboat.cpp
+use clap::Parser;
+use std::path::PathBuf;
+
 #[derive(Debug, Parser, Clone, PartialEq, Eq)]
 #[clap(author = "Salvador Guzman")]
 #[clap(name = "irontide", version = "0.1.0", about = "Rust port of Newsboat")]

--- a/src/local/cli/mod.rs
+++ b/src/local/cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod args;

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -1,1 +1,3 @@
+pub mod cli;
+#[cfg(feature = "gui")]
 mod iced;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,11 @@
 use env_logger::{Builder, Env};
-
 use colored::Colorize;
+use clap::Parser;
+use std::path::Path;
+
+mod rss;
+mod local;
+use local::cli::args::CliArgs;
 
 const PROGRAM_NAME: &str = "irontide";
 
@@ -52,5 +57,13 @@ fn init() {
 
 fn main() {
     init();
+    let args = CliArgs::parse();
+
+    if let Some(url_file) = args.url_file.as_ref() {
+        if let Err(e) = rss::process_urls_file(Path::new(url_file)) {
+            eprintln!("Error processing URLs file: {e}");
+        }
+    }
+
     std::process::exit(0);
 }

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,0 +1,2 @@
+pub mod rss;
+pub mod local;

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -1,0 +1,35 @@
+use feed_rs::{model::Feed, parser};
+use reqwest::blocking;
+use std::io::Cursor;
+
+pub fn fetch_feed(url: &str) -> Result<Feed, Box<dyn std::error::Error>> {
+    let response = blocking::get(url)?;
+    let bytes = response.bytes()?;
+    let feed = parser::parse(Cursor::new(bytes))?;
+    Ok(feed)
+}
+
+pub fn print_feed(feed: &Feed) {
+    if let Some(title) = &feed.title {
+        println!("# {}", title.content);
+    }
+    for entry in &feed.entries {
+        if let Some(entry_title) = &entry.title {
+            println!("- {}", entry_title.content);
+        }
+    }
+}
+
+pub fn process_urls_file(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let contents = std::fs::read_to_string(path)?;
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        println!("Fetching {}...", line);
+        let feed = fetch_feed(line)?;
+        print_feed(&feed);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- expose `cli` module and gate experimental Iced module behind `gui` feature
- add `feed-rs` dependency and enable `reqwest` blocking mode
- implement `rss` module to fetch and print feeds
- wire CLI parsing in `main` to read `--url-file`
- document usage in `README`

## Testing
- `cargo fmt -- --check`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68634621fd108332a5b7573daa4242ee