### PR TITLE
Improve CLI handling and logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,9 @@ ice-rs = "0.3.0"
 libc = { version = "0.2.172", features = ["const-extern-fn", "use_std"] }
 log = "0.4.27"
 rand = { version = "0.9.1", features = ["log", "serde"] }
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["blocking", "rustls-tls"] }
+feed-rs = "2.3.1"
 rusqlite = "0.35.0"
+
+[features]
+gui = []

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ cargo build
 
 The project is still in a very early stage but should compile with the stable Rust toolchain.
 
+## Usage
+
+Irontide can read a list of feed URLs from a file and print their titles:
+
+```bash
+irontide --url-file urls.txt
+```
+
+Each non-empty, non-comment line in `urls.txt` should contain a valid feed URL.
+
+Run `irontide -h` to see all available options. The `--log-level` flag controls
+the verbosity of logging from 1 (errors only) up to 6 (debug).
+
+## Running tests
+
+Basic unit tests verify the command-line interface. Run them with:
+
+```bash
+cargo test
+```
+
 ## License
 
 The code is released under the terms of the CC0 license. See the [LICENSE](LICENSE) file for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod local;
+pub mod rss;

--- a/src/local/cli/args.rs
+++ b/src/local/cli/args.rs
@@ -1,7 +1,16 @@
 // CLI arguments struct, derived from C++ options in newsboat.cpp
+use clap::Parser;
+use std::path::PathBuf;
+
 #[derive(Debug, Parser, Clone, PartialEq, Eq)]
 #[clap(author = "Salvador Guzman")]
-#[clap(name = "irontide", version = "0.1.0", about = "Rust port of Newsboat")]
+#[clap(
+    name = "irontide",
+    version = "0.1.0",
+    about = "Rust port of Newsboat",
+    disable_version_flag = true,
+    disable_help_flag = true
+)]
 pub struct CliArgs {
     #[clap(
         short = 'e',
@@ -97,6 +106,7 @@ pub struct CliArgs {
         short = 'l',
         long = "log-level",
         value_name = "loglevel",
+        value_parser = clap::value_parser!(u8).range(1..=6),
         help = "write a log with given log level (1-6)"
     )]
     pub log_level: Option<u8>,

--- a/src/local/cli/mod.rs
+++ b/src/local/cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod args;

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -1,1 +1,3 @@
+pub mod cli;
+#[cfg(feature = "gui")]
 mod iced;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,23 @@
-use env_logger::{Builder, Env};
-
+use clap::{CommandFactory, Parser};
 use colored::Colorize;
+use env_logger::{Builder, Env};
+use irontide::local::cli::args::CliArgs;
+use std::path::Path;
 
 const PROGRAM_NAME: &str = "irontide";
 
-fn setup_logging() {
-    Builder::from_env(Env::default().default_filter_or("info"))
+fn setup_logging(level: Option<u8>) {
+    let mut builder = Builder::from_env(Env::default().default_filter_or("info"));
+    if let Some(level) = level {
+        let filter = match level {
+            6 => log::LevelFilter::Debug,
+            5 => log::LevelFilter::Info,
+            4 => log::LevelFilter::Warn,
+            _ => log::LevelFilter::Error,
+        };
+        builder.filter_level(filter);
+    }
+    builder
         .format(|buf, record| {
             let timestamp = chrono::Local::now()
                 .format("%Y-%m-%d %H:%M:%S%.3f")
@@ -45,12 +57,32 @@ fn atexit() {
     }
 }
 
-fn init() {
-    setup_logging();
+fn init(args: &CliArgs) {
+    setup_logging(args.log_level);
     atexit();
 }
 
 fn main() {
-    init();
+    let args = CliArgs::parse();
+
+    if args.help {
+        CliArgs::command().print_help().unwrap();
+        println!();
+        return;
+    }
+
+    if args.version {
+        println!("{} {}", PROGRAM_NAME, env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
+    init(&args);
+
+    if let Some(url_file) = args.url_file.as_ref() {
+        if let Err(e) = irontide::rss::process_urls_file(Path::new(url_file)) {
+            eprintln!("Error processing URLs file: {e}");
+        }
+    }
+
     std::process::exit(0);
 }

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -1,0 +1,35 @@
+use feed_rs::{model::Feed, parser};
+use reqwest::blocking;
+use std::io::Cursor;
+
+pub fn fetch_feed(url: &str) -> Result<Feed, Box<dyn std::error::Error>> {
+    let response = blocking::get(url)?;
+    let bytes = response.bytes()?;
+    let feed = parser::parse(Cursor::new(bytes))?;
+    Ok(feed)
+}
+
+pub fn print_feed(feed: &Feed) {
+    if let Some(title) = &feed.title {
+        println!("# {}", title.content);
+    }
+    for entry in &feed.entries {
+        if let Some(entry_title) = &entry.title {
+            println!("- {}", entry_title.content);
+        }
+    }
+}
+
+pub fn process_urls_file(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let contents = std::fs::read_to_string(path)?;
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        println!("Fetching {}...", line);
+        let feed = fetch_feed(line)?;
+        print_feed(&feed);
+    }
+    Ok(())
+}

--- a/tests/cliargs.rs
+++ b/tests/cliargs.rs
@@ -1,0 +1,51 @@
+use clap::Parser;
+use irontide::local::cli::args::CliArgs;
+use std::path::PathBuf;
+
+#[test]
+fn unknown_option_is_error() {
+    let res = CliArgs::try_parse_from(["irontide", "--bad-option"]);
+    assert!(res.is_err());
+}
+
+#[test]
+fn import_from_opml_parses() {
+    let args = CliArgs::try_parse_from(["irontide", "-i", "feeds.opml"]).unwrap();
+    assert_eq!(args.import_from_opml, Some(PathBuf::from("feeds.opml")));
+}
+
+#[test]
+fn refresh_on_start_flag() {
+    let args = CliArgs::try_parse_from(["irontide", "--refresh-on-start"]).unwrap();
+    assert!(args.refresh_on_start);
+}
+
+#[test]
+fn export_to_opml_flag() {
+    let args = CliArgs::try_parse_from(["irontide", "--export-to-opml"]).unwrap();
+    assert!(args.export_to_opml);
+}
+
+#[test]
+fn url_file_option() {
+    let args = CliArgs::try_parse_from(["irontide", "--url-file", "urls.txt"]).unwrap();
+    assert_eq!(args.url_file, Some(PathBuf::from("urls.txt")));
+}
+
+#[test]
+fn log_file_option() {
+    let args = CliArgs::try_parse_from(["irontide", "--log-file", "app.log"]).unwrap();
+    assert_eq!(args.log_file, Some(PathBuf::from("app.log")));
+}
+
+#[test]
+fn log_level_option() {
+    let args = CliArgs::try_parse_from(["irontide", "--log-level", "5"]).unwrap();
+    assert_eq!(args.log_level, Some(5));
+}
+
+#[test]
+fn log_level_out_of_range() {
+    assert!(CliArgs::try_parse_from(["irontide", "--log-level", "0"]).is_err());
+    assert!(CliArgs::try_parse_from(["irontide", "--log-level", "7"]).is_err());
+}


### PR DESCRIPTION
## Summary
- validate log level argument and map it to `log` filters
- display custom help and version information
- document log-level usage in README
- add tests for invalid log-level values

## Testing
- `cargo fmt -- --check`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68634621fd108332a5b7573daa4242ee